### PR TITLE
Remove unsafe #__PURE__ annotation

### DIFF
--- a/src/stylis-rtl.js
+++ b/src/stylis-rtl.js
@@ -26,7 +26,6 @@ function stylisRTLPlugin(context: StylisContextType, content: string): ?string {
 
 // stable identifier that will not be dropped by minification unless the whole module
 // is unused
-/*#__PURE__*/
 Object.defineProperty(stylisRTLPlugin, "name", { value: "stylisRTLPlugin" });
 
 export default stylisRTLPlugin;


### PR DESCRIPTION
Terser's output with this annotation:
```js
import r from"cssjanus";export const STYLIS_PROPERTY_CONTEXT=-1;function t(t,o){if(-1===t)return r.transform(o)}export default t;
```

Notice that `Object.defineProperty` call is gone, because of a `#__PURE__` annotation put before it. That annotation should be IMHO used **only** before calls that are assigned to smth, so like:
```js
var foo = /*#__PURE__*/ createFoo()
```
so when `foo` stays unused then `createFoo` can be dropped as well. 